### PR TITLE
Fix screen initialization mismatch

### DIFF
--- a/src/screens/battle.py
+++ b/src/screens/battle.py
@@ -2,10 +2,12 @@ import pygame
 from game import ScreenNames
 
 class BattleScreen:
-    def __init__(self, app): self.app = app
+    def __init__(self, screen, game):
+        self.screen = screen
+        self.game = game
     def on_enter(self): pass
     def handle_event(self, event): pass
     def update(self, dt): pass
     def draw(self):
-        self.app.screen.fill((0,100,0))
+        self.screen.fill((0,100,0))
         pass

--- a/src/screens/end.py
+++ b/src/screens/end.py
@@ -2,10 +2,12 @@ import pygame
 from game import ScreenNames
 
 class EndScreen:
-    def __init__(self, app): self.app = app
+    def __init__(self, screen, game):
+        self.screen = screen
+        self.game = game
     def on_enter(self): pass
     def handle_event(self, event): pass
     def update(self, dt): pass
     def draw(self):
-        self.app.screen.fill((100,0,0))
+        self.screen.fill((100,0,0))
         pass

--- a/src/screens/highscore.py
+++ b/src/screens/highscore.py
@@ -2,10 +2,12 @@ import pygame
 from game import ScreenNames
 
 class HighscoreScreen:
-    def __init__(self, app): self.app = app
+    def __init__(self, screen, game):
+        self.screen = screen
+        self.game = game
     def on_enter(self): pass
     def handle_event(self, event): pass
     def update(self, dt): pass
     def draw(self):
-        self.app.screen.fill((20,20,100))
+        self.screen.fill((20,20,100))
         pass

--- a/src/screens/player_v_bot.py
+++ b/src/screens/player_v_bot.py
@@ -2,8 +2,9 @@ import pygame
 from screen_names import ScreenNames  # Geändert von: from game import ScreenNames
 
 class PlayerVBotScreen:
-    def __init__(self, app):
-        self.app = app
+    def __init__(self, screen, game):
+        self.screen = screen
+        self.game = game
         
     def on_enter(self): 
         pass
@@ -15,5 +16,5 @@ class PlayerVBotScreen:
         pass
     
     def draw(self):
-        self.app.screen.fill((80,80,80))
+        self.screen.fill((80,80,80))
         pass

--- a/src/screens/player_vs_bot.py
+++ b/src/screens/player_vs_bot.py
@@ -2,9 +2,9 @@ import pygame
 from screen_names import ScreenNames
 
 class PlayerVsBotScreen:
-    def __init__(self, app):
-        self.game = app
-        self.screen = app.screen
+    def __init__(self, screen, game):
+        self.screen = screen
+        self.game = game
         self.width = self.screen.get_width()
         self.height = self.screen.get_height()
         

--- a/src/screens/settings.py
+++ b/src/screens/settings.py
@@ -2,9 +2,9 @@ import pygame
 from screen_names import ScreenNames
 
 class SettingsScreen:
-    def __init__(self, app):  # Changed to take single app parameter
-        self.game = app
-        self.screen = app.screen
+    def __init__(self, screen, game):
+        self.screen = screen
+        self.game = game
         self.width = self.screen.get_width()
         self.height = self.screen.get_height()
         


### PR DESCRIPTION
## Summary
- standardize constructors for multiple screens
- make GameApp compatible with screen changes

## Testing
- `pytest -q`
- `python src/main.py` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_6842f547ed348332a27844690cab5cec